### PR TITLE
fix: Tetris - Ignore keypress events when game is pause

### DIFF
--- a/resource/game/tetris/main.js
+++ b/resource/game/tetris/main.js
@@ -6,7 +6,7 @@ const ctxNext = canvasNext.getContext('2d');
 let accountValues = {
   score: 0,
   level: 0,
-  lines: 0
+  lines: 0,
 };
 
 function updateAccount(key, value) {
@@ -21,19 +21,19 @@ let account = new Proxy(accountValues, {
     target[key] = value;
     updateAccount(key, value);
     return true;
-  }
+  },
 });
 
 let requestId = null;
 let time = null;
 
 const moves = {
-  [KEY.LEFT]: (p) => ({ ...p, x: p.x - 1 }),
-  [KEY.RIGHT]: (p) => ({ ...p, x: p.x + 1 }),
-  [KEY.DOWN]: (p) => ({ ...p, y: p.y + 1 }),
-  [KEY.SPACE]: (p) => ({ ...p, y: p.y + 1 }),
-  [KEY.UP]: (p) => board.rotate(p, ROTATION.RIGHT),
-  [KEY.Q]: (p) => board.rotate(p, ROTATION.LEFT)
+  [KEY.LEFT]: p => ({ ...p, x: p.x - 1 }),
+  [KEY.RIGHT]: p => ({ ...p, x: p.x + 1 }),
+  [KEY.DOWN]: p => ({ ...p, y: p.y + 1 }),
+  [KEY.SPACE]: p => ({ ...p, y: p.y + 1 }),
+  [KEY.UP]: p => board.rotate(p, ROTATION.RIGHT),
+  [KEY.Q]: p => board.rotate(p, ROTATION.LEFT),
 };
 
 let board = new Board(ctx, ctxNext);
@@ -53,6 +53,12 @@ function addEventListener() {
 }
 
 function handleKeyPress(event) {
+  if (!requestId) {
+    if (event.keyCode === KEY.P) {
+      pause();
+    }
+    return;
+  }
   if (event.keyCode === KEY.P) {
     pause();
   }
@@ -63,11 +69,11 @@ function handleKeyPress(event) {
     let p = moves[event.keyCode](board.piece);
     if (event.keyCode === KEY.SPACE) {
       if (document.querySelector('#pause-btn').style.display === 'block') {
-          dropSound.play();
-      }else{
+        dropSound.play();
+      } else {
         return;
       }
-      
+
       while (board.valid(p)) {
         account.score += POINTS.HARD_DROP;
         board.piece.move(p);
@@ -79,8 +85,10 @@ function handleKeyPress(event) {
         movesSound.play();
       }
       board.piece.move(p);
-      if (event.keyCode === KEY.DOWN && 
-          document.querySelector('#pause-btn').style.display === 'block') {
+      if (
+        event.keyCode === KEY.DOWN &&
+        document.querySelector('#pause-btn').style.display === 'block'
+      ) {
         account.score += POINTS.SOFT_DROP;
       }
     }
@@ -135,11 +143,11 @@ function gameOver() {
   ctx.font = '1px Arial';
   ctx.fillStyle = 'red';
   ctx.fillText('GAME OVER', 1.8, 4);
-  
+
   sound.pause();
   finishSound.play();
   checkHighScore(account.score);
-  sendScore('player1',account.score);
+  sendScore('player1', account.score);
   document.querySelector('#pause-btn').style.display = 'none';
   document.querySelector('#play-btn').style.display = '';
 }
@@ -171,7 +179,7 @@ function showHighScores() {
   const highScoreList = document.getElementById('highScores');
 
   highScoreList.innerHTML = highScores
-    .map((score) => `<li>${score.score} - ${score.name}`)
+    .map(score => `<li>${score.score} - ${score.name}`)
     .join('');
 }
 


### PR DESCRIPTION
# Pull Request Template

## Type of PR

- [ ] Feature - Platform
- [x] Feature - Game
- [ ] Fix - Bug

## Description of PR
This PR introduces a new feature in the game where keypress events are ignored during the pause state.
This enhancement aims to improve game control and prevent unintended actions when the game is paused.

## Changes Made
Added a check in the handleKeyPress function to ignore keypress events when the game is paused.

## Testing Method
The feature can be tested by pausing the game using the 'P' key and attempting to use other controls. Key presses should be ignored until the game is unpaused. 

## Related Issues
#9 

## Checklist

- [x] Prepared for code review (Assignees set, Labels applied, etc.)
- [x] Checked that changes do not negatively affect existing features
- [ ] Documentation completed for new features
- [ ] All unit tests passed
- [ ] Testing in the test environment completed
- [x] Linked this PR in the related issue
- [ ] Communicated sufficiently with the relevant team or person before submitting PR
