### PR TITLE
fix: Update scoreboard immediately after game ends

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,7 @@ export function activate(context: vscode.ExtensionContext) {
       const panel = createWebviewPanel(context, game);
       panel.webview.html = getHtmlContent(context, panel.webview, game);
 
-      handlePanelMessages(panel, context, game.id);
+      handlePanelMessages(panel, context, game.id, scoreBoardProvider);
       openWebviews.set(game.id, panel);
 
       panel.onDidDispose(() => openWebviews.delete(game.id));

--- a/src/score-board-provider.ts
+++ b/src/score-board-provider.ts
@@ -13,6 +13,15 @@ export class ScoreBoardProvider implements vscode.TreeDataProvider<ScoreItem> {
     private gameId: string
   ) {}
 
+  private _onDidChangeTreeData: vscode.EventEmitter<ScoreItem | undefined> =
+    new vscode.EventEmitter<ScoreItem | undefined>();
+  readonly onDidChangeTreeData: vscode.Event<ScoreItem | undefined> =
+    this._onDidChangeTreeData.event;
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire();
+  }
+
   getTreeItem(element: ScoreItem): vscode.TreeItem {
     return element;
   }

--- a/src/util/handle-panel-message.ts
+++ b/src/util/handle-panel-message.ts
@@ -1,16 +1,20 @@
 import * as vscode from 'vscode';
 import saveScore from './save-score';
+import { ScoreBoardProvider } from '../score-board-provider';
+
 /**
  * message handler for a webview panel.
  * This function listense for messages sent from the webview and performs actions based on the message content.
  * @param panel
  * @param context
  * @param gameId
+ * @param scoreBoardProvider
  */
 function handlePanelMessages(
   panel: vscode.WebviewPanel,
   context: vscode.ExtensionContext,
-  gameId: string
+  gameId: string,
+  scoreBoardProvider: ScoreBoardProvider
 ) {
   panel.webview.onDidReceiveMessage(
     message => {
@@ -18,6 +22,7 @@ function handlePanelMessages(
         const score = message.score;
         const player = message.player;
         saveScore(context, gameId, { player, score });
+        scoreBoardProvider.refresh();
       }
     },
     undefined,


### PR DESCRIPTION
# Pull Request Template

## Type of PR

- [x] Feature - Platform
- [ ] Feature - Game
- [ ] Fix - Bug

## Description of PR
This PR addresses an issue where the scoreboard does not update immediately after the game ends. Adds real-time update functionality to the scoreboard.

## Changes Made
- Added the scoreBoardProvider.refresh() method within the handlePanelMessages function. This update ensures that the scoreboard is instantly refreshed in response to panel messages, especially after game completion.
- Implemented a new refresh method in the scoreboard provider. This method triggers the _onDidChangeTreeData event emitter, which is essential for updating the ScoreItem in real-time.
- The changes ensure that the scoreboard reflects the most current game data, improving the real-time feedback loop during game sessions.

## Testing Method

<!-- Describe how this PR can be tested. -->

## Related Issues
#32 

## Live Demo

https://github.com/hp-potion/vsc-gameboy/assets/92978646/af5e9d46-2d6b-4f3d-b19c-832ce37a1150


## Checklist

- [x] Prepared for code review (Assignees set, Labels applied, etc.)
- [x] Checked that changes do not negatively affect existing features
- [ ] Documentation completed for new features
- [ ] All unit tests passed
- [ ] Testing in the test environment completed
- [x] Linked this PR in the related issue
- [ ] Communicated sufficiently with the relevant team or person before submitting PR
