### PR TITLE
fix:Remove compile error

### DIFF
--- a/src/score-board-provider.ts
+++ b/src/score-board-provider.ts
@@ -19,7 +19,7 @@ export class ScoreBoardProvider implements vscode.TreeDataProvider<ScoreItem> {
     this._onDidChangeTreeData.event;
 
   refresh(): void {
-    this._onDidChangeTreeData.fire();
+    this._onDidChangeTreeData.fire(undefined);
   }
 
   getTreeItem(element: ScoreItem): vscode.TreeItem {


### PR DESCRIPTION
# Pull Request Template

## Type of PR

- [ ] Feature - Platform
- [ ] Feature - Game
- [x] Fix - Bug

## Description of PR
This PR addresses a compile error that was occurring due to the improper firing of an event without an explicitly defined argument. The fix involved adding undefined as an argument to the this._onDidChangeTreeData.fire() method call.

## Changes Made
Modified the refresh() method in undefined to include undefined as an argument in this._onDidChangeTreeData.fire().

## Testing Method
Compile the code to ensure that the previous compile error no longer occurs.
Test the functionality where this._onDidChangeTreeData.fire() is used to ensure it behaves as expected.

## Related Issues

<!-- If there are related issues, link them here. -->

## Checklist

- [x] Prepared for code review (Assignees set, Labels applied, etc.)
- [x] Checked that changes do not negatively affect existing features
- [ ] Documentation completed for new features
- [ ] All unit tests passed
- [ ] Testing in the test environment completed
- [ ] Linked this PR in the related issue
- [x] Communicated sufficiently with the relevant team or person before submitting PR
